### PR TITLE
IMR-46 feat : Increase the crop size to fit the screen.

### DIFF
--- a/front/src/components/page/CropPage.jsx
+++ b/front/src/components/page/CropPage.jsx
@@ -52,6 +52,7 @@ function CropPage() {
         <div className="container-cropper">
           <div className="cropper">
             <Cropper
+              objectFit="cover"
               image={imgurl}
               crop={crop}
               zoom={zoom}


### PR DESCRIPTION
## Overview
- 크롭 화면에서 일부 이미지의 경우(가로 세로가 긴) 크롭 사이즈가 화면에서 엄청 작게 보이는 문제가 있었습니다.
- 때문에 크롭 사이즈를 화면에 맞췄습니다.
- 변경 후 이렇게 보입니다.
<img width="479" alt="image" src="https://github.com/boostcampaitech5/level3_recsys_finalproject-recsys-03/assets/7973448/a87893f0-b085-4327-bc2a-649e383702ee">

## To Reviewer
- [여기](http://localhost:30009/upload)에서 크롭 화면이 어떻게 보이는지 확인할 수 있습니다.

## Issue Link
- [Jira Issue](https://btcamplevel3.atlassian.net/jira/software/projects/IMR/boards/4?selectedIssue=IMR-46)