### PR TITLE
IMR-50 fix : 유튜브 컴포넌트가 2번씩 업데이트 되는 오류 수정

### DIFF
--- a/front/src/components/page/MusicRecommend.jsx
+++ b/front/src/components/page/MusicRecommend.jsx
@@ -63,10 +63,6 @@ class MusicRecommend extends PureComponent {
         modalOpen: state.modalOpen,
         songInfo: songInfos[e.target.swiper.realIndex],
       }));
-
-      this.youTubeVideoRef.current.changeVideoId(
-        songInfos[e.target.swiper.realIndex].videoYtId
-      );
     };
   }
 
@@ -112,7 +108,7 @@ class MusicRecommend extends PureComponent {
           <h2>지금 노래를 들어보세요</h2>
           <YouTubeVideo
             ref={this.youTubeVideoRef}
-            videoId={songInfos.videoYtId}
+            videoId={songInfo.videoYtId}
           />
         </div>
         <div className="footer">

--- a/front/src/components/page/MusicSelector.jsx
+++ b/front/src/components/page/MusicSelector.jsx
@@ -12,14 +12,14 @@ export default class MusicSelector extends PureComponent {
 
   componentDidMount() {
     this.swiperElRef.current.addEventListener(
-      'slidechange',
+      'realindexchange',
       this.onSlideChange
     );
   }
 
   componentWillUnmount() {
     this.swiperElRef.current.removeEventListener(
-      'slidechange',
+      'realindexchange',
       this.onSlideChange
     );
   }

--- a/front/src/components/page/YouTubeVideo.jsx
+++ b/front/src/components/page/YouTubeVideo.jsx
@@ -4,23 +4,8 @@ import YouTube from 'react-youtube';
 import './YouTubeVideo.css';
 
 export default class YouTubeVideo extends PureComponent {
-  constructor(props) {
-    super(props);
-
-    this.state = {
-      videoId: props.videoId,
-    };
-  }
-
-  // eslint-disable-next-line react/no-unused-class-component-methods
-  changeVideoId(videoId) {
-    this.setState({
-      videoId,
-    });
-  }
-
   render() {
-    const { videoId } = this.state;
+    const { videoId } = this.props;
     return (
       <div className="YouTubeVideo">
         <YouTube


### PR DESCRIPTION
## Overview
- 이미지 추천 결과 화면에서,
- 카드를 넘길때마다 유튜브 컴포넌트가 두번씩 업데이트되는 오류를 수정합니다. 

## Change Log
- 기존의 react스럽지 않은 코드를 삭제했습니다. (외부에서 컴포넌트의 함수를 호출함 -> `changeVideoId`)
- swiper의 event를 `slidechange`에서  `realindexchange`로 변경했습니다.
    - swiper에서 loop옵션을 키면 swiper가 뒤에 생기는 구조라서 이벤트가 2번 호출됩니다.
    - 따라서 다른 이벤트가 필요했습니다. [참고](https://github.com/nolimits4web/Swiper/issues/2435)

## To Reviewer
- **개발 모드**에선 react strictmode를 사용해 컴포넌트가 `mount -> unmount -> remount` 구조를 거칩니다.
- **배포 모드**에서 확인해볼 필요가 있습니다. [참고](https://velog.io/@sonaky47/React-18-StrictMode-%EC%97%90%EC%84%9C-api-%ED%98%B8%EC%B6%9C-%EB%91%90%EB%B2%88-%EB%90%98%EB%8A%94-%EB%AC%B8%EC%A0%9C-%ED%95%B4%EA%B2%B0%ED%95%98%EA%B8%B0-StrictMode-%EC%A0%9C%EA%B1%B0-%EC%97%86%EC%9D%B4)
- 배포모드는 [여기](http://118.67.128.125:30008/music-rec)서 한시적으로 확인할 수 있습니다.

## Issue Link
- [Jira Issue](https://btcamplevel3.atlassian.net/jira/software/projects/IMR/boards/4?selectedIssue=IMR-50)