### PR TITLE
IMR-55 fix: rename work name to contain tag_type

### DIFF
--- a/ml/run_finetune.py
+++ b/ml/run_finetune.py
@@ -14,7 +14,7 @@ from src.utils import (
 def main(config) -> None:
     set_seed(config.seed)
     config.timestamp = get_timestamp()
-    config.wandb.name = f"work-{config.timestamp}"
+    config.wandb.name = f"{config.data.tag_type}-{config.timestamp}"
     login_wandb()
     init_wandb(config)
 


### PR DESCRIPTION
## Overview
- output과 wandb로깅에 활용되는 이름에 tag_type을 명시해주었습니다.

## Change Log
- work -> tag_type으로 변경

## To Reviewer
- 브랜치 삭제해주세요!

## Issue Link
- [Jira Issue](https://btcamplevel3.atlassian.net/browse/IMR-55?atlOrigin=eyJpIjoiOGY1NGQ0NGQzMzgwNDdmMTk1OWFiNGU4MjI4OTg2MWUiLCJwIjoiaiJ9)