### PR TITLE
IMR-59 fix : 이미지 크롭 화면에서 이미지 비율 문제 수정

### DIFF
--- a/front/src/components/page/CropPage.css
+++ b/front/src/components/page/CropPage.css
@@ -14,6 +14,7 @@
   font-size: 1em;
   font-weight: 400;
 }
+
 .CropPage .cropper {
   position: relative;
   width: 100%;
@@ -21,8 +22,8 @@
 }
 
 .CropPage .container-cropper {
-  height: 60%;
-  width: 90%;
+  height: 360px;
+  width: 360px;
   background-color: #e3e3e3;
   margin: auto;
 }


### PR DESCRIPTION
## Overview
- 이미지 크롭 화면에서 이미지가 정사각형일때, 확대된 상태에서 무조건 이미지를 잘라야 하는 오류를 수정합니다.

## To Reviewer
- [여기](http://118.67.128.125:30009/)에서 변경사항을 확인할 수 있습니다.

## Issue Link
- [Jira Issue](https://btcamplevel3.atlassian.net/jira/software/projects/IMR/boards/4?selectedIssue=IMR-59)