### PR TITLE
IMR-98 fix: change save directory

### DIFF
--- a/ml/run_preprocessing.py
+++ b/ml/run_preprocessing.py
@@ -18,7 +18,7 @@ def main(config) -> None:
     tag_type = config.tag_type
     repo_id = config.repo_id
     name = train_file[:-4]
-    save_dir = os.path.join(data_dir, f"{tag_file}_dataset/{name}")
+    save_dir = os.path.join(data_dir, f"{tag_type}_dataset/{name}")
 
     # generate subset dataset (tag == [weather, situation, mood])
     pd.set_option("mode.chained_assignment", None)


### PR DESCRIPTION
## Overview
- local에 dataset이 저장될 때의 directory를 수정했습니다.

## Change Log
- tag_file 이름이 아닌 {tag_type}_dataset에 dataset이 저장될 수 있도록 수정했습니다.

## Issue Link
- [Jira Issue](https://btcamplevel3.atlassian.net/browse/IMR-98?atlOrigin=eyJpIjoiMDBmOTA1YTU5ZDNkNDdlOGFiMTU2MGFjYmI3OTAyZGYiLCJwIjoiaiJ9)