### PR TITLE
IMR-109 fix: DEL gif in input img accept

### DIFF
--- a/front/src/components/page/UploadPage.jsx
+++ b/front/src/components/page/UploadPage.jsx
@@ -120,7 +120,7 @@ function ImageUploadPage() {
         <input
           type="file"
           id="file"
-          accept="image/png, image/jpg, image/jpeg, image/gif, image/heic, image/heif"
+          accept="image/png, image/jpg, image/jpeg, image/heic, image/heif"
           onChange={(e) => insertImg(e)}
           style={{ display: 'none' }}
         />


### PR DESCRIPTION
## Overview
- 입력 이미지로 gif를 넣을 수 없도록 합니다.

## Change Log
- UploadPage.jsx 수정

## To Reviewer
<img width="334" alt="image" src="https://github.com/boostcampaitech5/level3_recsys_finalproject-recsys-03/assets/118340911/bb80e2f1-b237-4117-8a1d-5750257589e8"> 

위와 같이 잘 동작하는 것 확인했습니다!

## Issue Link
- [Jira Issue](https://btcamplevel3.atlassian.net/browse/IMR-109?atlOrigin=eyJpIjoiNjY2NzI1ZTVlNWRjNDRkY2I5Nzc4ODcwYjU5YzhmZTEiLCJwIjoiaiJ9)