### PR TITLE
IMR-96/feat: upload index file to HF Hub

### DIFF
--- a/ml/configs/indexing/config.yaml
+++ b/ml/configs/indexing/config.yaml
@@ -1,6 +1,7 @@
 seed: 42
-repo_id: RecDol/PL_Multilabel
-name: weather-17_061939
-data_dir: ./input/data
+model_repo_id: RecDol/PL_Multilabel
+index_repo_id: RecDol/faiss_index
+name: mood-19_110133
+data_dir: ./input/data/PLAYLIST
 output_dir: ./output/
-tag_type: weather #choice = [weather, mood , sit]
+tag_type: mood #choice = [weather, mood , sit]

--- a/ml/run_indexing.py
+++ b/ml/run_indexing.py
@@ -1,6 +1,7 @@
 import os
 import faiss
 import hydra
+from huggingface_hub import HfApi
 from transformers import AutoImageProcessor, AutoModel
 from src.utils import set_seed, encode, read_dataset
 
@@ -11,14 +12,16 @@ def main(config) -> None:
     data_dir = config.data_dir
     output_dir = config.output_dir
     tag_type = config.tag_type
-    repo = config.repo_id
+    model_repo = config.model_repo_id
+    index_repo = config.index_repo_id
     subfolder = f"{tag_type}/{name}/{name}_huggingface"
     save_dir = os.path.join(output_dir, name)
+    save_file = f"{save_dir}/{tag_type}.index"
     set_seed(config.seed)
 
     # init model
-    processor = AutoImageProcessor.from_pretrained(repo, subfolder=subfolder)
-    model = AutoModel.from_pretrained(repo, subfolder=subfolder)
+    processor = AutoImageProcessor.from_pretrained(model_repo, subfolder=subfolder)
+    model = AutoModel.from_pretrained(model_repo, subfolder=subfolder)
     # load dataset
     dataset = read_dataset(data_dir, tag_type)
     # encode
@@ -31,6 +34,10 @@ def main(config) -> None:
     dataset_with_embeddings.drop_index(index_name="embeddings")
     dataset_with_embeddings.save_to_disk(os.path.join(save_dir, f"{tag_type}_dataset"))
 
+    api = HfApi()
+    api.upload_file(
+        path_or_fileobj=save_dir, path_in_repo=f"{tag_type}/{name}", repo_id=index_repo, commit_message=f"upload index: {name}", repo_type="dataset"
+    )
 
 @hydra.main(version_base="1.2", config_path="configs/indexing", config_name="config.yaml")
 def main_hydra(config) -> None:


### PR DESCRIPTION
## Overview
- index파일을 허브에 업로드하도록 수정했습니다.

## Change Log
- dataset 레포를 클론한 위치에 맞게 config를 수정했습니다.
- config에 model repo와 index repo를 추가했습니다.
- index생성이 완료되면 index 파일이 RecDol/faiss_index레포에 올라갑니다.

## Issue Link
- [Jira Issue](https://btcamplevel3.atlassian.net/browse/IMR-96?atlOrigin=eyJpIjoiNDQwYTIxZGRlOWY1NDVkYWJiNmIwOTA0NTZiMmU0YzUiLCJwIjoiaiJ9)