### PR TITLE
IMR-110 feat : FastAPI 모델 인퍼런스 query embedding에 normalization 추가

### DIFF
--- a/back/src/infer/playlist.py
+++ b/back/src/infer/playlist.py
@@ -1,4 +1,5 @@
 import os
+import faiss
 import datasets
 import numpy as np
 from PIL import Image
@@ -106,6 +107,7 @@ class PlaylistIdExtractor:
         self, query_image: Image, processor: ViTImageProcessor, model: ViTModel, dataset: Dataset, k: int
     ) -> Tuple[np.ndarray, dict]:
         query_embedding = model(**processor(query_image, return_tensors="pt"))
-        query_embedding = query_embedding.last_hidden_state[:, 0].detach().numpy().squeeze()
-        scores, retrieved_examples = dataset.get_nearest_examples("embeddings", query_embedding, k=k)
+        query_embedding = query_embedding.last_hidden_state[:, 0].detach().numpy()
+        faiss.normalize_L2(query_embedding)
+        scores, retrieved_examples = dataset.get_nearest_examples("embeddings", query_embedding.squeeze(), k=k)
         return scores, retrieved_examples


### PR DESCRIPTION
## Overview
- indexing 단계에서 코사인 유사도를 similarity score로 사용하도록 변경하였습니다.
- 이에 맞춰, 모델 인퍼런스 단계에도 사용자가 입력한 쿼리 이미지에 대한 임베딩 벡터를 얻은 후 normalization 하는 로직을 추가했습니다.

## Change Log
- squeeze전에 normalize 하도록 수정, normalize된 벡터가 get_nearest_examples에 넘겨지도록 수정

## To Reviewer
- merge 후 branch 삭제 부탁드립니다.

## Issue Link
- [Jira Issue](https://btcamplevel3.atlassian.net/jira/software/projects/IMR/boards/4/backlog?selectedIssue=IMR-110)