### PR TITLE
IMR-111 fix: fix fileobj at upload_file

### DIFF
--- a/ml/run_indexing.py
+++ b/ml/run_indexing.py
@@ -36,7 +36,7 @@ def main(config) -> None:
 
     api = HfApi()
     api.upload_file(
-        path_or_fileobj=save_dir, path_in_repo=f"{tag_type}/{name}", repo_id=index_repo, commit_message=f"upload index: {name}", repo_type="dataset"
+        path_or_fileobj=save_file, path_in_repo=f"{tag_type}/{name}", repo_id=index_repo, commit_message=f"upload index: {name}", repo_type="dataset"
     )
 
 @hydra.main(version_base="1.2", config_path="configs/indexing", config_name="config.yaml")


### PR DESCRIPTION
## Overview
-저장할 파일이 잘못 지정되어 허브에 인덱스파일이 올라가지 않는 문제를 해결했습니다.

## Change Log
- save dir -> save file로 저장대상 변경

## Issue Link
- [Jira Issue](https://btcamplevel3.atlassian.net/browse/IMR-111?atlOrigin=eyJpIjoiODA0NGZjMjFkOTUwNGIxM2JlMDM4NzFkMzQ2ZWE0ODYiLCJwIjoiaiJ9)