### PR TITLE
IMR-117 fix: fix file path when uploading index

### DIFF
--- a/ml/run_indexing.py
+++ b/ml/run_indexing.py
@@ -16,7 +16,7 @@ def main(config) -> None:
     index_repo = config.index_repo_id
     subfolder = f"{tag_type}/{name}/{name}_huggingface"
     save_dir = os.path.join(output_dir, name)
-    save_file = f"{save_dir}/{tag_type}.index"
+    save_file = f"{save_dir}/{name}.index"
     set_seed(config.seed)
 
     # init model
@@ -36,7 +36,7 @@ def main(config) -> None:
 
     api = HfApi()
     api.upload_file(
-        path_or_fileobj=save_file, path_in_repo=f"{tag_type}/{name}", repo_id=index_repo, commit_message=f"upload index: {name}", repo_type="dataset"
+        path_or_fileobj=save_file, path_in_repo=f"{tag_type}/{name}.index", repo_id=index_repo, commit_message=f"upload index: {name}", repo_type="dataset"
     )
 
 @hydra.main(version_base="1.2", config_path="configs/indexing", config_name="config.yaml")


### PR DESCRIPTION
## Overview
- index파일이 업로드될때 .index확장자가 붙지 않은채로 업로드되는 문제를 개선했습니다.

## Change Log
- path_in_repo를 수정했습니다.
- index file이 저장될때 사용한 모델명과 동일하도록 바꿔주었습니다.

## To Reviewer
- 이제 정말 마지막 허브 저장방식 수정이었으면 좋겠습니다..^^

## Issue Link
- [Jira Issue](https://btcamplevel3.atlassian.net/browse/IMR-117?atlOrigin=eyJpIjoiYWRlMjZlNDMwNjg0NDYzY2IxNDc2Yzk1YTczZmZmNGQiLCJwIjoiaiJ9)