### PR TITLE
IMR-119 refactor: modify dataset loading logic

### DIFF
--- a/back/README.md
+++ b/back/README.md
@@ -20,7 +20,7 @@ conda init
 (back) mkdir hub
 (back) cd hub
 (back) git clone https://huggingface.co/datasets/RecDol/PLAYLIST
-(back) git clone https://huggingface.co/datasets/RecDol/index
+(back) git clone https://huggingface.co/datasets/RecDol/faiss_index
 (back) git clone https://huggingface.co/datasets/RecDol/CsvFiles
 ```
 

--- a/back/src/router/root_router.py
+++ b/back/src/router/root_router.py
@@ -21,7 +21,7 @@ song_k = 15
 top_k = 6  # song_k must be more than 6 or loop of silder must be False
 
 
-playlist = PlaylistIdExtractor(k=pl_k, is_data_pull=False)
+playlist = PlaylistIdExtractor(k=pl_k, is_data_pull=True)
 song = SongIdExtractor(k=song_k, is_data_pull=True)
 
 


### PR DESCRIPTION
## Overview
- hugginface hub 에서 데이터셋을 로드하는 방법이 변경되어 이를 반영하였습니다.

## Change Log
- faiss index를 불러오는 레포 주소가 변경되었습니다
- dataset을 불러오는 방법이 변경되었습니다 (레포 내 각 타입에 따라서 concat)

## To Reviewer
- 서비스가 정상적으로 동작하는 것을 확인하였습니다
- weather 데이터셋은 아직 오류가 해결되지 않아 기존 방법으로 로드하게 두었습니다.

## Issue Link
- [Jira Issue](https://btcamplevel3.atlassian.net/browse/IMR-119?atlOrigin=eyJpIjoiMDQzNThiNThkNDg3NDRmNGFkYTI1M2RkMjlmZjNiZDYiLCJwIjoiaiJ9)