### PR TITLE
IMR-165 fix : UpdatedAtMixin pre_save안먹히는 오류 수정

### DIFF
--- a/back/src/db/document/auth.py
+++ b/back/src/db/document/auth.py
@@ -1,7 +1,5 @@
 from mongoengine import Document, StringField, ReferenceField
 from ...dto.model import Auth
-
-# from datetime import datetime
 from ...config import AppConfig
 from .user import UserDocument
 from .mixin.date import CreatedAtMixin

--- a/back/src/db/document/mixin/date.py
+++ b/back/src/db/document/mixin/date.py
@@ -24,5 +24,6 @@ class UpdatedAtMixin:
     updated_at = DateTimeField(default=utcnow)
     meta = {"abstract": True}
 
-
-signals.pre_save.connect(update_updated_at, sender=UpdatedAtMixin)
+    def __init_subclass__(cls, **kwargs):
+        super().__init_subclass__(**kwargs)
+        signals.pre_save.connect(update_updated_at, sender=cls)


### PR DESCRIPTION
## Overview
- UpdatedAtMixin을 상속한 Document가 수정되었을때, updated_at이 갱신이 안되는 오류를 수정합니다.

## Change Log
- AuthDocument의 안쓰는 import 주석 삭제
- UpdatedAtMixin의 __init_subclass__를 이용해 AuthDocument에 pre_save signal을 등록

## To Reviewer
- 이제 오류는 다 수정되었으니 잘 쓰십시오~

## Issue Link
- [Jira Issue](https://btcamplevel3.atlassian.net/jira/software/projects/IMR/boards/4?selectedIssue=IMR-165)